### PR TITLE
Fix a few lint warnings

### DIFF
--- a/mobile-web/src/amp-url-creator.js
+++ b/mobile-web/src/amp-url-creator.js
@@ -134,8 +134,7 @@ function constructCacheDomainUrl_(url, opt_cacheUrlAuthority) {
  *    string.
  *
  * @param {string} url The complete publisher url.
- * @return {string} The curls encoded domain
- * @return {!Promise<string>}
+ * @return {!Promise<string>} The curls encoded domain.
  * @private
  */
 export function constructCacheDomain_(url) {

--- a/mobile-web/src/viewer-messaging.js
+++ b/mobile-web/src/viewer-messaging.js
@@ -88,7 +88,7 @@ export class ViewerMessaging {
         } else {
           this.messageHandler_(data.name, data.data, data.rsvp);
         }
-      }
+      };
     }
   }
 
@@ -113,7 +113,7 @@ export class ViewerMessaging {
             resolve();
           });
         }
-      }
+      };
       this.win.addEventListener('message', listener);
     });
   }

--- a/mobile-web/src/viewer.js
+++ b/mobile-web/src/viewer.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import {constructViewerCacheUrl} from './amp-url-creator';
-import {ViewerMessaging} from './viewer-messaging';
 import {History} from './history';
+import {ViewerMessaging} from './viewer-messaging';
+import {constructViewerCacheUrl} from './amp-url-creator';
 import {log} from '../utils/log';
 import {parseUrl} from '../utils/url';
 
@@ -57,7 +57,7 @@ class Viewer {
   /**
    * @param {!Function} showViewer method that shows the viewer.
    * @param {!Function} hideViewer method that hides the viewer.
-   * @param {!Function():boolean} isViewerHidden method that determines if viewer is hidden.
+   * @param {!function():boolean} isViewerHidden method that determines if viewer is hidden.
    */
   setViewerShowAndHide(showViewer, hideViewer, isViewerHidden) {
     /** @private {!Function} */

--- a/mobile-web/utils/log.js
+++ b/mobile-web/utils/log.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-
+/**
+ * Logs an arbitrary list of arguments to the console using viewer-specific
+ * lead-ins.
+ */
 export function log() {
   const var_args = Array.prototype.slice.call(arguments, 0);
   var_args.unshift('[Viewer]');


### PR DESCRIPTION
1. 
```
Function must have JSDoc.
  export function log() {
         ^^^^^^^^^^^^^^^^
```

2. import statements are not sorted.

3. 
```Missing semicolon
      channel.port1.onmessage = e => {
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

4.
```
Bad type annotation. expected closing } See https://github.com/google/closure-compiler/wiki/Bad-Type-Annotation for more information.
   * @param {!Function():boolean} isViewerHidden method that determines if viewer is hidden.
```

5. Extra @return clauses in the JsDoc