### PR TITLE
Update CURLS CDN checking to be more robust.

### DIFF
--- a/ios/AMPKit/Categories/NSURL+AMPK.h
+++ b/ios/AMPKit/Categories/NSURL+AMPK.h
@@ -38,6 +38,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSString *)ampPath;
 
+/**
+ * Returns if the current URL matches the given CDN URL. This method is agnostic to checking the
+ * equivalence of CURLS vs non-CURLS CDN URLs. This way, you can check if a non-CURLS URL matches to
+ * its CURLS counterpart.
+ * @param source The CDN URL you want to compare the current URL to.
+ */
+- (BOOL)matchesCDNURL:(NSURL *)source;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/AMPKit/Categories/NSURL+AMPK.m
+++ b/ios/AMPKit/Categories/NSURL+AMPK.m
@@ -29,6 +29,20 @@ static NSDictionary *kAMPSharingBasePathMapping(void) {
 
 @implementation NSURL (AMP)
 
+// We need to validate hostname match for both CURLS and non-CURLS addresses (which get redirects).
+// If the non-CURLS adddress is redirected to CURLS, the host name won't match, but, the path still
+// will and the source host name will be a subdomain (cdn.ampproject.org) of the new CURLS address.
+- (BOOL)matchesCDNURL:(NSURL *)source {
+  NSURL *baseProxyURL = [NSURL URLWithString:kDefaultAMPProxyPrefix];
+  if ([self.host isEqualToString:source.host]) {
+    return YES;
+  } else if ([source.host hasSuffix:baseProxyURL.host] &&
+             [self.lastPathComponent isEqualToString:source.lastPathComponent]) {
+    return YES;
+  }
+  return NO;
+}
+
 /** Returns the authority of the URL, which is the host + port if the port is not 80. */
 - (NSString *)authority {
   NSMutableString *authority = [[self host] mutableCopy];

--- a/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.h
+++ b/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.h
@@ -26,7 +26,7 @@
 
 @property(nonatomic, weak) AMPKWebViewerViewController *ampWebViewerController;
 @property(nonatomic, weak) AMPKMessageBroadcaster *ampMessageBroadcaster;
-@property(nonatomic, copy) NSString *sourceHostName;
+@property(nonatomic, copy) NSURL *source;
 
 /** Send AMP page message via AMP JS channel. */
 - (void)sendAmpJsMessage:(AMPKWebViewerJsMessage *)message;

--- a/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
+++ b/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
@@ -24,6 +24,7 @@
 #import "AMPKWebViewerMessageHandlerController_private.h"
 #import "AMPKWebViewerViewController.h"
 #import "AMPKWebViewerViewController_private.h"
+#import "NSURL+AMPK.h"
 
 static NSString * const AMPKJSBundle = @"AmpKit.bundle";
 static NSString * const AMPKJSName = @"amp_integration";
@@ -143,7 +144,7 @@ static NSString *AMPKLoadAmpIntegrationSource(void) {
   }
 }
 
-- (void)sendVisible:(BOOL)visible{
+- (void)sendVisible:(BOOL)visible {
   // Until some message has been received, we could not have received the document loaded message.
   // Therefore, don't even bother creating the message and requesting it be sent as it will not.
   if (!_lastMessage) {
@@ -182,7 +183,7 @@ static NSString *AMPKLoadAmpIntegrationSource(void) {
 - (void)userContentController:(WKUserContentController *)userContentController
       didReceiveScriptMessage:(WKScriptMessage *)message {
   // Check the message host matches with current URL host.
-  if ([_sourceHostName isEqualToString:message.frameInfo.request.URL.host]) {
+  if ([message.frameInfo.request.URL matchesCDNURL:self.source]) {
     AMPKWebViewerJsMessage *ampMessage = [message ampWebViewerJsMessage];
     AMPKWebViewerBaseMessageHandler *handler = self.messageHandlers[ampMessage.name];
     [handler handleMessage:message forAmpWebViewerController:self.ampWebViewerController];

--- a/ios/AMPKit/ViewControllers/AMPKWebViewerViewController.m
+++ b/ios/AMPKit/ViewControllers/AMPKWebViewerViewController.m
@@ -154,7 +154,6 @@ NSString * const AMPKHeaderNameField = @"X-AMP-VIEWER";
   self.view.hidden = !visible;
 }
 
-
 - (void)loadAmpArticle:(id<AMPKArticleProtocol>)article
            withHeaders:(nullable NSDictionary<NSString *, NSString *> *)headers {
   if ([self.article.publisherURL isEqual:article.publisherURL]) {
@@ -170,7 +169,7 @@ NSString * const AMPKHeaderNameField = @"X-AMP-VIEWER";
   NSAssert(self.article.publisherURL.host,
              @"Must have a valid Host for AMP URL: %@",
              self.article.publisherURL);
-  _messageHandlerController.sourceHostName = [[self proxiedURL] host];
+  _messageHandlerController.source = [self proxiedURL];
   _messageHandlerController.ampWebViewerController = self;
 
   NSURL *url = [[self proxiedURL] URLBySettingProxyHashFragmentsForDomain:_domainName];

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKMessageBroadcasterTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKMessageBroadcasterTest.m
@@ -417,7 +417,7 @@ static NSString *const kTestBroadcastMessageURLString = @"http://www.nope.com";
       handler = [self strickMockForHandler];
     } else {
       handler = [[AMPKWebViewerMessageHandlerController alloc] init];
-      handler.sourceHostName = kAmpKitTestSourceHostName;
+      handler.source = [NSURL URLWithString:kAmpKitTestSourceHostName];
     }
 
     [set addObject:handler];

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.m
@@ -23,7 +23,7 @@
 
 #import <OCMock/OCMock.h>
 
-NSString *const kAmpKitTestSourceHostName = @"www.google.com";
+NSString *const kAmpKitTestSourceHostName = @"https://cdn.ampproject.org";
 static NSString *const kTestBroadcastMessageURLString = @"http://www.nope.com";
 
 @implementation AMPKTestHelper
@@ -38,10 +38,8 @@ static NSString *const kTestBroadcastMessageURLString = @"http://www.nope.com";
   id jsMessageMock = OCMPartialMock([[WKScriptMessage alloc] init]);
 
   id wkFrameInfoMock = OCMStrictClassMock([WKFrameInfo class]);
-  id nsUrlMock = OCMStrictClassMock([NSURL class]);
-  [[[nsUrlMock stub] andReturn:kAmpKitTestSourceHostName] host];
   id nsUrlRequestMock = OCMStrictClassMock([NSURLRequest class]);
-  [[[nsUrlRequestMock stub] andReturn:nsUrlMock] URL];
+  [[[nsUrlRequestMock stub] andReturn:[NSURL URLWithString:kAmpKitTestSourceHostName]] URL];
   [[[wkFrameInfoMock stub] andReturn:nsUrlRequestMock] request];
 
   NSMutableDictionary *scriptData =

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKWebViewerMessageHandlerControllerTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKWebViewerMessageHandlerControllerTest.m
@@ -37,7 +37,7 @@
 - (void)setUp {
   [super setUp];
   self.messageHandlerController = [[AMPKWebViewerMessageHandlerController alloc] init];
-  self.messageHandlerController.sourceHostName = kAmpKitTestSourceHostName;
+  self.messageHandlerController.source = [NSURL URLWithString:kAmpKitTestSourceHostName];
 }
 
 - (void)tearDown {
@@ -54,7 +54,7 @@
                                                                  data:nil
                                                                 error:nil];
 
-  self.messageHandlerController.sourceHostName = @"nope.com";
+  self.messageHandlerController.source = [NSURL URLWithString:@"nope.com"];
 
   [self.messageHandlerController userContentController:[WKUserContentController new]
                                didReceiveScriptMessage:mockWKScriptMessage];

--- a/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
@@ -132,4 +132,33 @@ static NSString *kDomainName = @"https://www.google.com";
   NSString *cdnString = @"https://cdn.ampproject.org/c/www.test.com/sites/";
   XCTAssert([[url ampk_ProxiedURL].absoluteString isEqualToString:cdnString]);
 }
+
+- (void)testCDNMatchesForCURLS {
+  NSString *url = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSURL *CURLSCDN = [NSURL URLWithString:url];
+  XCTAssertTrue([CURLSCDN matchesCDNURL:CURLSCDN]);
+}
+
+- (void)testCDNMatchesForNonCURLS {
+  NSString *url = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSURL *nonCURLSCDN = [NSURL URLWithString:url];
+  XCTAssertTrue([nonCURLSCDN matchesCDNURL:nonCURLSCDN]);
+}
+
+- (void)testCDNNonCURLSMatchesCURLS {
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSURL *CURLSCDN = [NSURL URLWithString:CURLSURL];
+  NSURL *nonCURLSCDN = [NSURL URLWithString:nonCURLSURL];
+  XCTAssertTrue([nonCURLSCDN matchesCDNURL:CURLSCDN]);
+}
+
+- (void)testCDNCURLSMatchesNonCURLS {
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSURL *CURLSCDN = [NSURL URLWithString:CURLSURL];
+  NSURL *nonCURLSCDN = [NSURL URLWithString:nonCURLSURL];
+  XCTAssertTrue([CURLSCDN matchesCDNURL:nonCURLSCDN]);
+}
+
 @end

--- a/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
@@ -134,28 +134,28 @@ static NSString *kDomainName = @"https://www.google.com";
 }
 
 - (void)testCDNMatchesForCURLS {
-  NSString *url = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *url = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
   NSURL *CURLSCDN = [NSURL URLWithString:url];
   XCTAssertTrue([CURLSCDN matchesCDNURL:CURLSCDN]);
 }
 
 - (void)testCDNMatchesForNonCURLS {
-  NSString *url = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *url = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
   NSURL *nonCURLSCDN = [NSURL URLWithString:url];
   XCTAssertTrue([nonCURLSCDN matchesCDNURL:nonCURLSCDN]);
 }
 
 - (void)testCDNNonCURLSMatchesCURLS {
-  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
-  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
+  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
   NSURL *CURLSCDN = [NSURL URLWithString:CURLSURL];
   NSURL *nonCURLSCDN = [NSURL URLWithString:nonCURLSURL];
   XCTAssertTrue([nonCURLSCDN matchesCDNURL:CURLSCDN]);
 }
 
 - (void)testCDNCURLSMatchesNonCURLS {
-  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
-  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality"; // NOLINT
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
+  NSString *nonCURLSURL = @"https://cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
   NSURL *CURLSCDN = [NSURL URLWithString:CURLSURL];
   NSURL *nonCURLSCDN = [NSURL URLWithString:nonCURLSURL];
   XCTAssertTrue([CURLSCDN matchesCDNURL:nonCURLSCDN]);


### PR DESCRIPTION
Specifically, when handling conversion between non CURLS and redirected CURLS addresses.

Add tests to check for this case specifically.