### PR TITLE
Add support for prerender visibility state via the AMP Runtime.

### DIFF
--- a/ios/AMPKit/AMPKViewer.h
+++ b/ios/AMPKit/AMPKViewer.h
@@ -52,6 +52,12 @@
  */
 @property(nonatomic, readonly) NSInteger currentViewerIndex;
 
+/**
+ * Sets the |currentAmpWebViewerController| visibility state to prerender. Use this if you want to
+ * physically present the AMPKViewer on screen but not change the visibility state to visible.
+ * Swiping or other activity in the viewer will override this state.
+ */
+@property(nonatomic) BOOL isPrefetched;
 
 - (instancetype)initWithViewerDataSource:(AMPKViewerDataSource *)viewerDataSource
     NS_DESIGNATED_INITIALIZER;

--- a/ios/AMPKit/AMPKViewer.m
+++ b/ios/AMPKit/AMPKViewer.m
@@ -79,6 +79,15 @@
   self.currentAmpWebViewerController.presenter = _presenter;
 }
 
+- (void)setIsPrefetched:(BOOL)isPrefetched {
+  if (isPrefetched == _isPrefetched) return;
+
+  _isPrefetched = isPrefetched;
+  if (!isPrefetched) {
+    [_currentAmpWebViewerController setVisible:YES];
+  }
+}
+
 #pragma mark - State Restoration
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder {
@@ -121,6 +130,7 @@
   if (!completed) {
     return;
   }
+  self.isPrefetched = NO;
 
   NSAssert(_currentAmpWebViewerController == previousViewControllers.firstObject,
             @"currentAmpWebViewController %@ must be in preivousViewController %@",

--- a/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.h
+++ b/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.h
@@ -34,6 +34,9 @@
 /** Send a visibility state message to the webview. */
 - (void)sendVisible:(BOOL)visible;
 
+/** Send a visibility state message of prerender to the webview. */
+- (void)sendPrefetched;
+
 /** Forward a broadcast message from some other webview to this webview. */
 - (void)forwardBroadcast:(AMPKWebViewerJsMessage *)broadcast;
 

--- a/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
+++ b/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
@@ -160,9 +160,9 @@ static NSDictionary *kAMPKVisibilityState(void) {
   // Therefore, don't even bother creating the message and requesting it be sent as it will not.
   if (!_lastMessage) {
     return;
-    AMPKVisibilityState state = visible ? AMPKVisibilityStateVisible : AMPKVisibilityStateHidden;
-    [self sendVisibilityState:state];
   }
+  AMPKVisibilityState state = visible ? AMPKVisibilityStateVisible : AMPKVisibilityStateHidden;
+  [self sendVisibilityState:state];
 }
 
 - (void)sendPrefetched {

--- a/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
+++ b/ios/AMPKit/Runtime/AMPKWebViewerMessageHandlerController.m
@@ -25,6 +25,12 @@
 #import "AMPKWebViewerViewController.h"
 #import "AMPKWebViewerViewController_private.h"
 
+typedef NS_ENUM(NSInteger, AMPKVisibilityState) {
+  AMPKVisibilityStatePrefetched,
+  AMPKVisibilityStateVisible,
+  AMPKVisibilityStateHidden,
+};
+
 static NSString * const AMPKJSBundle = @"AmpKit.bundle";
 static NSString * const AMPKJSName = @"amp_integration";
 static NSString * const AMPKJSExtension = @"js";
@@ -47,6 +53,12 @@ static NSString *AMPKLoadAmpIntegrationSource(void) {
   });
   return jsContents;
 };
+
+static NSDictionary *kAMPKVisibilityState(void) {
+  return @{ @(AMPKVisibilityStateVisible) : @"visible",
+            @(AMPKVisibilityStateHidden) : @"inactive",
+            @(AMPKVisibilityStatePrefetched) : @"prerender" };
+}
 
 @implementation AMPKWebViewerMessageHandlerController {
   WKUserScript *_ampIntegrationScript;
@@ -148,9 +160,22 @@ static NSString *AMPKLoadAmpIntegrationSource(void) {
   // Therefore, don't even bother creating the message and requesting it be sent as it will not.
   if (!_lastMessage) {
     return;
+    AMPKVisibilityState state = visible ? AMPKVisibilityStateVisible : AMPKVisibilityStateHidden;
+    [self sendVisibilityState:state];
   }
+}
 
-  NSString *state = (visible ? @"visible" : @"inactive");
+- (void)sendPrefetched {
+  // Until some message has been received, we could not have received the document loaded message.
+  // Therefore, don't even bother creating the message and requesting it be sent as it will not.
+  if (!_lastMessage) {
+    return;
+  }
+  [self sendVisibilityState:AMPKVisibilityStatePrefetched];
+}
+
+- (void)sendVisibilityState:(AMPKVisibilityState)visibilityState {
+  NSString *state = kAMPKVisibilityState()[@(visibilityState)];
   AMPKWebViewerJsMessage *message =
       [AMPKWebViewerJsMessage messageWithType:AMPKMessageTypeRequest
                                          name:kAmpVisibilityChangeMessageName


### PR DESCRIPTION
This allows users to physically display the AMPViewer on screen but not have the viewer change to the "Visible" state.

This is useful for cases where the AMP viewer is embedded inside another view controller and those view controllers are being added to a view hierarchy but are not yet visible.

For instance, adding the AMP viewer inside a collection view cell where the cell is not on screen yet. This allows prefetching without improperly setting visibility in those cases.