### PR TITLE
Add methods to sanitize manually specified CDN URLs.

### DIFF
--- a/ios/AMPKit/Categories/NSURL+AMPK.h
+++ b/ios/AMPKit/Categories/NSURL+AMPK.h
@@ -46,6 +46,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)matchesCDNURL:(NSURL *)source;
 
+/**
+ * Returns the sanitized version of the CDN URL. For AMPKit, CDN URLs that include the AMP JS
+ * version via the "v" parameter or that try to directly initialize the runtime cannot be used. This
+ * method should be called on any URL you try to pass to AMPKit as a CDN URL to ensure it is in a
+ * safe form. Returns nil if the URL cannot be recognized as a CDN URL.
+ */
+- (nullable NSURL *)sanitizedCDNURL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/AMPKit/Models/AMPKArticle.m
+++ b/ios/AMPKit/Models/AMPKArticle.m
@@ -60,6 +60,10 @@ NS_ASSUME_NONNULL_BEGIN
   return ampArticle;
 }
 
+- (void)setCdnURL:(nullable NSURL *)cdnURL {
+  _cdnURL = [cdnURL sanitizedCDNURL];
+}
+
 - (BOOL)isEqual:(id)object {
   if (object == self) {
     return YES;

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKArticleTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKArticleTest.m
@@ -42,27 +42,27 @@
 - (void)testCDNURLEqual {
   AMPKArticle *article1 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]
-                           cdnURL:[NSURL URLWithString:@"http://www.test.com"]];
+                           cdnURL:[NSURL URLWithString:@"http://cdn.ampproject.org/c/test"]];
   AMPKArticle *article2 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]
-                           cdnURL:[NSURL URLWithString:@"http://www.test.com"]];
+                           cdnURL:[NSURL URLWithString:@"http://cdn.ampproject.org/c/test"]];
   XCTAssertEqualObjects(article1, article2);
 }
 
 - (void)testCDNURLNotEqual {
   AMPKArticle *article1 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]
-                           cdnURL:[NSURL URLWithString:@"http://www.test.com"]];
+                           cdnURL:[NSURL URLWithString:@"http://cdn.ampproject.org/c/test"]];
   AMPKArticle *article2 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]
-                           cdnURL:[NSURL URLWithString:@"http://www.test.com/test"]];
+                           cdnURL:[NSURL URLWithString:@"http://cdn.ampproject.org/c/test2"]];
   XCTAssertNotEqualObjects(article1, article2);
 }
 
 - (void)testCDNURLNil {
   AMPKArticle *article1 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]
-                           cdnURL:[NSURL URLWithString:@"http://www.test.com"]];
+                           cdnURL:[NSURL URLWithString:@"http://cdn.ampproject.org/c/test"]];
   AMPKArticle *article2 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]];
   XCTAssertNotEqualObjects(article1, article2);
@@ -95,6 +95,22 @@
   AMPKArticle *article2 =
       [AMPKArticle articleWithURL:[NSURL URLWithString:@"http://www.google.com"]];
   XCTAssertNotEqualObjects(article1, article2);
+}
+
+- (void)testSettingNonSanitizedCDN {
+  NSString *articleURL = @"http://www.google.com";
+  NSString *cdnURL = @"https://cdn.ampproject.org/v/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event?amp_js_v=0.1#test=1&visibilityState=prerender";
+  AMPKArticle *article = [AMPKArticle articleWithURL:[NSURL URLWithString:articleURL]
+                                              cdnURL:[NSURL URLWithString:cdnURL]];
+  XCTAssertNotEqualObjects(cdnURL, article.cdnURL.absoluteString);
+}
+
+- (void)testSettingSanitizedCDN {
+  NSString *articleURL = @"http://www.google.com";
+  NSString *cdnURL = @"https://cdn.ampproject.org/c/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event";
+  AMPKArticle *article = [AMPKArticle articleWithURL:[NSURL URLWithString:articleURL]
+                                              cdnURL:[NSURL URLWithString:cdnURL]];
+  XCTAssertEqualObjects(cdnURL, article.cdnURL.absoluteString);
 }
 
 @end

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKPrefetchControllerTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKPrefetchControllerTest.m
@@ -22,6 +22,7 @@
 #import "AMPKViewer.h"
 #import "AMPKViewerDataSource.h"
 #import "AMPKWebViewerViewController.h"
+#import "AMPKTestHelper.h"
 
 #import <OCMock/OCMock.h>
 
@@ -53,8 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testInvalidCDNURL {
-  NSArray <AMPKArticle *> *validArticles =
-      @[[AMPKArticle articleWithURL:[NSURL URLWithString:@"https://www.google.com/test"]
+  NSArray <id<AMPKArticleProtocol>> *validArticles =
+  @[[AMPKTestArticle articleWithURL:[NSURL URLWithString:@"https://www.google.com/test"]
                              cdnURL:[NSURL URLWithString:@""]]];
   [self.subject ampViewerWithArticles:validArticles usingHeaders:nil prefetchedAtIndex:0];
   XCTAssertEqual(self.subject.ampViewController.viewerDataSource.count, 0);

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.h
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "AMPKArticleProtocol.h"
 #import "AMPKWebViewerJsMessage.h"
 
 extern NSString *const kAmpKitTestSourceHostName;
@@ -45,5 +46,21 @@ extern NSString *const kAmpKitTestSourceHostName;
 
 /** Creates a class mock for a WKSAMPKWebViewerViewController with the specified article URL. */
 + (id)mockViewerWithURL:(NSURL *)url;
+
+@end
+
+/**
+ * A class which simply implements AMPKArticleProtocol without any of the excess bounds checking of
+ * AMPKArticle. This allows us to test some of the edge conditions inside the framework that
+ * AMPKArticle catches automatically.
+ */
+@interface AMPKTestArticle : NSObject <AMPKArticleProtocol>
+
+/**
+ * Creates and test article.
+ * @param articleURL The publisher's article URL to use.
+ * @param cdnURL The CDN ULR to use.
+ */
++ (instancetype)articleWithURL:(NSURL *)articleURL cdnURL:(NSURL *)cdnURL;
 
 @end

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKTestHelper.m
@@ -92,3 +92,42 @@ static NSString *const kTestBroadcastMessageURLString = @"http://www.nope.com";
 }
 
 @end
+
+@implementation AMPKTestArticle
+
+@synthesize cdnURL = _cdnURL;
+@synthesize publisherURL = _publisherURL;
+@synthesize canonicalURL = _canonicalURL;
+
++ (instancetype)articleWithURL:(NSURL *)articleURL cdnURL:(NSURL *)cdnURL {
+  AMPKTestArticle *article = [[AMPKTestArticle alloc] init];
+  article.publisherURL = articleURL;
+  article.cdnURL = cdnURL;
+  return article;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:self.cdnURL forKey:@"_cdn"];
+  [aCoder encodeObject:self.publisherURL forKey:@"_publishers"];
+  [aCoder encodeObject:self.canonicalURL forKey:@"_canonical"];
+}
+
+- (instancetype)copyWithZone:(NSZone *)zone {
+  AMPKTestArticle *copy = [[AMPKTestArticle alloc] init];
+  copy.cdnURL = self.cdnURL;
+  copy.publisherURL = self.publisherURL;
+  copy.canonicalURL = self.canonicalURL;
+  return copy;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+  self = [super init];
+  if (self) {
+    _cdnURL = [aDecoder decodeObjectForKey:@"_cdn"];
+    _publisherURL = [aDecoder decodeObjectForKey:@"_publishers"];
+    _canonicalURL = [aDecoder decodeObjectForKey:@"_canonical"];
+  }
+  return self;
+}
+
+@end

--- a/ios/AMPKitDemo/AMPKitDemoTests/AMPKViewerDataSourceTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/AMPKViewerDataSourceTest.m
@@ -20,6 +20,7 @@
 
 #import "AMPKArticle.h"
 #import "AMPKArticleProtocol.h"
+#import "AMPKTestHelper.h"
 #import "AMPKWebViewerViewController.h"
 #import "AMPKWebViewerViewController_private.h"
 
@@ -302,7 +303,7 @@
   NSMutableArray<id<AMPKArticleProtocol>> *articles = [NSMutableArray arrayWithCapacity:count];
   for (NSUInteger indx = 0; indx < count; indx++) {
     NSString *urlString = [NSString stringWithFormat:@"https://www.google.com/%@", @(indx)];
-    AMPKArticle *article = [[AMPKArticle alloc] init];
+    AMPKTestArticle *article = [[AMPKTestArticle alloc] init];
     article.publisherURL = [NSURL URLWithString:urlString];
     [articles addObject:article];
   }

--- a/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
@@ -161,4 +161,65 @@ static NSString *kDomainName = @"https://www.google.com";
   XCTAssertTrue([CURLSCDN matchesCDNURL:nonCURLSCDN]);
 }
 
+- (void)testNilForNonCDNURLSanitization {
+  NSURL *URL = [NSURL URLWithString:@"http://www.google.com"];
+  XCTAssertNil([URL sanitizedCDNURL]);
+}
+
+- (void)testNilForBaseCDNURLSanitization {
+  NSURL *URL = [NSURL URLWithString:@"http://cdn.ampproject.org"];
+  XCTAssertNil([URL sanitizedCDNURL]);
+}
+
+- (void)testNilForInvalidNumberOfPathsComponentsOnCDNURLSanitization {
+  NSURL *URL = [NSURL URLWithString:@"http://cdn.ampproject.org/dogs"];
+  XCTAssertNil([URL sanitizedCDNURL]);
+}
+
+- (void)testNilForNonArticleOnCDNURLSanitization {
+  NSURL *URL = [NSURL URLWithString:@"http://cdn.ampproject.org/two/three/four"];
+  XCTAssertNil([URL sanitizedCDNURL]);
+}
+
+- (void)testCDNDoesNotAlterSanitizedCDNURL {
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
+  NSURL *URL = [NSURL URLWithString:CURLSURL];
+  XCTAssertEqualObjects(URL, [URL sanitizedCDNURL]);
+}
+
+- (void)testDoesNotAlterSecurityStatusCDNURL {
+  NSString *invalidCURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality#test=1&visibilityState=prerender";
+  NSURL *invalidCURLSURLURL = [NSURL URLWithString:invalidCURLSURL];
+  NSString *CURLSURL = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/2016/4/25/11501484/what-in-the-world-is-obama-looking-at-in-virtual-reality";
+  NSURL *validCDNURL = [NSURL URLWithString:CURLSURL];
+  XCTAssertEqualObjects(validCDNURL, [invalidCURLSURLURL sanitizedCDNURL]);
+}
+
+- (void)testSanitizesURLWithInSecureCDNURL {
+  NSString *invalidCDN = @"https://www-theverge-com.cdn.ampproject.org/v/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event?amp_js_v=0.1#test=1&visibilityState=prerender";
+  NSString *sanitizedCDN = @"https://www-theverge-com.cdn.ampproject.org/c/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event";
+
+  NSURL *invalidCDNURL = [NSURL URLWithString:invalidCDN];
+  NSURL *sanitizedCDNURL = [NSURL URLWithString:sanitizedCDN];
+  XCTAssertEqualObjects(sanitizedCDNURL, [invalidCDNURL sanitizedCDNURL]);
+}
+
+- (void)testSanitizesURLWithSecureCDNURL {
+  NSString *invalidCDN = @"https://www-theverge-com.cdn.ampproject.org/v/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event?amp_js_v=0.1#test=1&visibilityState=prerender";
+  NSString *sanitizedCDN = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event";
+
+  NSURL *invalidCDNURL = [NSURL URLWithString:invalidCDN];
+  NSURL *sanitizedCDNURL = [NSURL URLWithString:sanitizedCDN];
+  XCTAssertEqualObjects(sanitizedCDNURL, [invalidCDNURL sanitizedCDNURL]);
+}
+
+- (void)testSanitizesNonCURLSURL {
+  NSString *invalidCDN = @"https://cdn.ampproject.org/v/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event?amp_js_v=0.1#test=1&visibilityState=prerender";
+  NSString *sanitizedCDN = @"https://cdn.ampproject.org/c/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event";
+
+  NSURL *invalidCDNURL = [NSURL URLWithString:invalidCDN];
+  NSURL *sanitizedCDNURL = [NSURL URLWithString:sanitizedCDN];
+  XCTAssertEqualObjects(sanitizedCDNURL, [invalidCDNURL sanitizedCDNURL]);
+}
+
 @end


### PR DESCRIPTION
Manually specified runtime versions or any query/hash parameters are not valid for AMPKit CDN URLs and need to be sanitized if they are provided.

For instance, given this manual AMP version URL:
https://www-theverge-com.cdn.ampproject.org/v/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event?amp_js_v=0.1#test=1&visibilityState=prerender

the AMPKit appropriate sanitized URL is:
https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event

Add new unit tests for the code. Required some modifications of existing unit tests since these error corrections were being used to test framework code in a few places.