### PR TITLE
Keep trailing '/' when sanitizing CDN URL

### DIFF
--- a/ios/AMPKit/Categories/NSURL+AMPK.m
+++ b/ios/AMPKit/Categories/NSURL+AMPK.m
@@ -40,6 +40,14 @@ static NSDictionary *kAMPSharingBasePathMapping(void) {
     }
     // We need to include the leading "/" since this is the first path component.
     pathComponents[0] = @"/c";
+    // Remember to append the trailing '/' to the new path components if it existed in the old path.
+    // By default, iOS will strip this. Some publishers are very sensitive to this slash so we need
+    // to keep it.
+    if ([components.path hasSuffix:@"/"]) {
+      NSString *lastComponent = [pathComponents lastObject];
+      lastComponent = [lastComponent stringByAppendingString:@"/"];
+      pathComponents[pathComponents.count - 1] = lastComponent;
+    }
     components.path = [pathComponents componentsJoinedByString:@"/"];
     components.query = nil;
     components.fragment = nil;

--- a/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
+++ b/ios/AMPKitDemo/AMPKitDemoTests/NSURLAMPTest.m
@@ -222,4 +222,13 @@ static NSString *kDomainName = @"https://www.google.com";
   XCTAssertEqualObjects(sanitizedCDNURL, [invalidCDNURL sanitizedCDNURL]);
 }
 
+- (void)testSanitizesURLWithTrailingSlash {
+  NSString *invalidCDN = @"https://www-theverge-com.cdn.ampproject.org/v/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event/?amp_js_v=0.1#test=1&visibilityState=prerender";
+  NSString *sanitizedCDN = @"https://www-theverge-com.cdn.ampproject.org/c/s/www.theverge.com/platform/amp/circuitbreaker/2017/9/6/16254802/new-iphone-change-event/";
+
+  NSURL *invalidCDNURL = [NSURL URLWithString:invalidCDN];
+  NSURL *sanitizedCDNURL = [NSURL URLWithString:sanitizedCDN];
+  XCTAssertEqualObjects(sanitizedCDNURL, [invalidCDNURL sanitizedCDNURL]);
+}
+
 @end


### PR DESCRIPTION
Append the trailing '/' to the new path components if it existed in the old path. By default, iOS will strip this. Some publishers are very sensitive to this slash so we need to keep it.