### PR TITLE
Fix broken find/replace across project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -51,12 +51,12 @@
       submitted to Licensor for inclusion in the Work by the copyright owner
       or by an individual or Legal Entity authorized to submit on behalf of
       the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communiampion sent
+      means any form of electronic, verbal, or written communication sent
       to the Licensor or its representatives, including but not limited to
-      communiampion on electronic mailing lists, source code control systems,
+      communication on electronic mailing lists, source code control systems,
       and issue tracking systems that are managed by, or on behalf of, the
       Licensor for the purpose of discussing and improving the Work, but
-      excluding communiampion that is conspicuously marked or otherwise
+      excluding communication that is conspicuously marked or otherwise
       designated in writing by the copyright owner as "Not a Contribution."
 
       "Contributor" shall mean Licensor and any individual or Legal Entity
@@ -178,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a


### PR DESCRIPTION
An accidental find/replace across the entire project seems to have caused a few mistakes in the LICENSE file.

Addresses https://github.com/ampproject/amphtml/issues/16272